### PR TITLE
add pip as a requirement

### DIFF
--- a/requirements/requirements.yml
+++ b/requirements/requirements.yml
@@ -3,5 +3,6 @@ channels:
   - defaults
 dependencies:
   - python>=3.10
+  - pip
   - pip:
     - copier>=6.1

--- a/tmpl/requirements/dev-requirements.yml
+++ b/tmpl/requirements/dev-requirements.yml
@@ -19,5 +19,6 @@ dependencies:
   - rstcheck
   - sphinx
   - sphinx-autobuild
+  - pip
   - pip:
     - flake8-pyproject


### PR DESCRIPTION
Add pip as a requirement in all requirement files.

- The one in the blueprint `requirements/requirements.yml` is mandatory as it should be possible to install without the dev env and then pip is installed in this step.
- The one in the templates `dev-requirements` is optional as pip is already installed from `requirements/requirements.yml`. I am in favor of still including it for the sake of clarity/ explicitness. 