### PR TITLE
Conditional deploy of html

### DIFF
--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy . yourproject
+        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl yourproject
     - uses: C2SM/sphinx-action@sphinx-latest
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -3,10 +3,10 @@ name: Build and publish blueprint documentation
 on:
   push:
     branches:
-    - '*'
+    - master
   pull_request:
     branches:
-      - dev_refactor
+      - '*'
 
 jobs:
   blueprint-docs-build:
@@ -25,7 +25,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-    if: github.ref == 'refs/heads/conditional_build_html'
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -13,9 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: create blueprint project example
+    - name: create blueprint environment
       run: |
         conda env create --name blueprint --file requirements/requirements.yml
+    - name: Create new project
+      run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
         conda run --name blueprint copier --force --data python_version=3.9 copy . yourproject
     - uses: C2SM/sphinx-action@sphinx-latest

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl example_project
+        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl ./docs/example_project
     - uses: C2SM/sphinx-action@sphinx-latest
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -9,7 +9,7 @@ on:
       - dev_refactor
 
 jobs:
-  blueprint-docs-build:
+- blueprint-docs-build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -22,7 +22,7 @@ jobs:
       with:
         name: DocumentationHTML
         path: docs/_build/
-  blueprint-docs-build-and-deploy:
+- blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
       #    if: github.ref == 'refs/heads/conditional_build_html'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -22,9 +22,9 @@ jobs:
       with:
         name: DocumentationHTML
         path: docs/_build/
- 
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
+    needs: blueprint-docs-build
     if: github.ref == 'refs/heads/conditional_build_html'
     steps:
       - uses: actions/download-artifact@v1

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -17,10 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/download-artifact@master
-      with:
-        name: GeneratedProject
-        path: flying_circus
+    - name: create blueprint project example
+      run: |
+        conda env create --name blueprint --file requirements/requirements.yml
+        # Note: Make sure python_version is consistent with python-version hardcoded above
+        conda run --name blueprint copier --force --data python_version=3.9 copy . yourproject
     - uses: C2SM/sphinx-action@sphinx-latest
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -25,7 +25,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-    if: github.ref == 'refs/heads/conditional_build_html'
+      #    if: github.ref == 'refs/heads/conditional_build_html'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl yourproject
+        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl example_project
     - uses: C2SM/sphinx-action@sphinx-latest
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -9,7 +9,7 @@ on:
       - dev_refactor
 
 jobs:
-  blueprint-docs:
+  blueprint-docs-build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -17,13 +17,21 @@ jobs:
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'
         docs-folder: "docs/"
-    # Great extra actions to compose with:
     # Create an artifact of the html output.
     - uses: actions/upload-artifact@v1
       with:
         name: DocumentationHTML
         path: docs/_build/
-    # Publish built docs to gh-pages branch.
+ 
+  blueprint-docs-build-and-deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/conditional_build_html'
+    steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: DocumentationHTML
+          path: docs/_build/
+   # Publish built docs to gh-pages branch.
     # ===============================
     - name: Commit documentation changes
       run: |

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -3,7 +3,7 @@ name: Build and publish blueprint documentation
 on:
   push:
     branches:
-    - *
+    - '*'
   pull_request:
     branches:
       - dev_refactor

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl ./docs/example_project
+        conda run --name blueprint copier -a copier.yaml --force --vcs-ref=HEAD python_version=3.9 copy . ./docs/example_project
         ls
         echo "===================================" 
         ls docs

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -36,8 +36,6 @@ jobs:
       - name: Commit documentation changes
         run: |
           pwd
-          ls docs
-          ls docs/_build
           git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
           cp -r docs/_build/html/* gh-pages/
           cd gh-pages

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -25,7 +25,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-      #    if: github.ref == 'refs/heads/conditional_build_html'
+    if: github.ref == 'refs/heads/conditional_build_html'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -3,7 +3,7 @@ name: Build and publish blueprint documentation
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
     - '*'
@@ -37,7 +37,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -37,7 +37,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-      if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -21,7 +21,7 @@ jobs:
         # Note: Make sure python_version is consistent with python-version hardcoded above
         conda run --name blueprint copier --force --vcs-ref=HEAD python_version=3.9 copy . ./docs/example_project
         ls
-        echo "===================================" 
+        echo "==================================="
         ls docs
         echo "==================================="
         ls docs/example_project

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -1,17 +1,20 @@
 name: Build and publish blueprint documentation
 
 on:
-  push:
-    branches:
-    - master
-  pull_request:
-    branches:
+  workflow_run:
+    workflows: ["new-project"]
+    push:
+      branches:
+      - master
+    pull_request:
+      branches:
       - '*'
+    types:
+      - completed
 
 jobs:
   blueprint-docs-build:
     runs-on: ubuntu-latest
-    needs: new-project
     steps:
     - uses: actions/checkout@v1
     - uses: actions/download-artifact@master

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -32,7 +32,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-    if: github.ref == 'refs/heads/master'
+      #if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier -a copier.yaml --force --vcs-ref=HEAD python_version=3.9 copy . ./docs/example_project
+        conda run --name blueprint copier --force --vcs-ref=HEAD python_version=3.9 copy . ./docs/example_project
         ls
         echo "===================================" 
         ls docs

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -20,8 +20,10 @@ jobs:
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
         conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl ./docs/example_project
-        ls 
+        ls
+        echo "===================================" 
         ls docs
+        echo "==================================="
         ls docs/example_project
     - uses: C2SM/sphinx-action@sphinx-latest
       with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -20,6 +20,9 @@ jobs:
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
         conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy ./tmpl ./docs/example_project
+        ls 
+        ls docs
+        ls docs/example_project
     - uses: C2SM/sphinx-action@sphinx-latest
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -11,8 +11,13 @@ on:
 jobs:
   blueprint-docs-build:
     runs-on: ubuntu-latest
+    needs: new-project
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/download-artifact@master
+      with:
+        name: GeneratedProject
+        path: flying_circus
     - uses: C2SM/sphinx-action@sphinx-latest
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -9,7 +9,7 @@ on:
       - dev_refactor
 
 jobs:
-- blueprint-docs-build:
+  blueprint-docs-build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -22,7 +22,7 @@ jobs:
       with:
         name: DocumentationHTML
         path: docs/_build/
-- blueprint-docs-build-and-deploy:
+  blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
       #    if: github.ref == 'refs/heads/conditional_build_html'
@@ -31,30 +31,30 @@ jobs:
         with:
           name: DocumentationHTML
           path: docs/_build/
-   # Publish built docs to gh-pages branch.
-    # ===============================
-    - name: Commit documentation changes
-      run: |
-        pwd
-        ls docs
-        echo ' '
-        ls docs/_build
-        git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
-        cp -r docs/_build/html/* gh-pages/
-        cd gh-pages
-        touch .nojekyll
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add .
-        git commit -m "Update documentation" -a || true
-        # The above command will fail if no changes were present, so we ignore
-        # that.
-    - name: Push changes
-      # this commit SHA corresponds to tag `v0.6.0`
-      uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
-      with:
-        force: true
-        branch: gh-pages
-        directory: gh-pages
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-    # ===============================
+      # Publish built docs to gh-pages branch.
+      # ===============================
+      - name: Commit documentation changes
+        run: |
+          pwd
+          ls docs
+          echo ' '
+          ls docs/_build
+          git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
+          cp -r docs/_build/html/* gh-pages/
+          cd gh-pages
+          touch .nojekyll
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+          # The above command will fail if no changes were present, so we ignore
+          # that.
+      - name: Push changes
+        # this commit SHA corresponds to tag `v0.6.0`
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6
+        with:
+          force: true
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      # ===============================

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -37,7 +37,6 @@ jobs:
         run: |
           pwd
           ls docs
-          echo ' '
           ls docs/_build
           git clone https://github.com/ammaraskar/sphinx-action-test.git --branch gh-pages --single-branch gh-pages
           cp -r docs/_build/html/* gh-pages/

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -25,7 +25,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-      #if: github.ref == 'refs/heads/conditional_build_html'
+    if: github.ref == 'refs/heads/conditional_build_html'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -1,16 +1,12 @@
 name: Build and publish blueprint documentation
 
 on:
-  workflow_run:
-    workflows: ["new-project"]
-    push:
-      branches:
-      - master
-    pull_request:
-      branches:
-      - '*'
-    types:
-      - completed
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - '*'
 
 jobs:
   blueprint-docs-build:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -3,7 +3,7 @@ name: Build and publish blueprint documentation
 on:
   push:
     branches:
-    - dev_refactor
+    - *
   pull_request:
     branches:
       - dev_refactor
@@ -25,7 +25,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-    if: github.ref == 'refs/heads/conditional_build_html'
+      #if: github.ref == 'refs/heads/conditional_build_html'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --data python_version=3.9 copy . yourproject
+        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy . yourproject
     - uses: C2SM/sphinx-action@sphinx-latest
       with:
         pre-build-command: 'pip3 install sphinx_mdinclude'

--- a/.github/workflows/blueprint-docs.yaml
+++ b/.github/workflows/blueprint-docs.yaml
@@ -37,7 +37,7 @@ jobs:
   blueprint-docs-build-and-deploy:
     runs-on: ubuntu-latest
     needs: blueprint-docs-build
-      #if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/blueprint-pre-commit.yml
+++ b/.github/workflows/blueprint-pre-commit.yml
@@ -3,10 +3,10 @@ name: Run pre-commit in blueprint
 on:
   push:
     branches:
-    - dev_refactor
+    - main
   pull_request:
     branches:
-    - dev_refactor
+    - '*'
 
 jobs:
   blueprint-pre-commit:

--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -3,10 +3,10 @@ name: Create new project and run tests etc.
 on:
   push:
     branches:
-    - dev_refactor
+    - main
   pull_request:
     branches:
-    - dev_refactor
+    - '*'
 
 jobs:
   new-project:

--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -41,6 +41,10 @@ jobs:
         git config user.email "monty.python@meteoswiss.ch"
         git add .
         git commit -m "initial commit"
+    - uses: actions/download-artifact@master
+      with:
+        name: GeneratedProject
+        path: flying_circus
     - name: Create dev env (unpinned) and install package
       working-directory: ./flying_circus
       run: |

--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -41,10 +41,6 @@ jobs:
         git config user.email "monty.python@meteoswiss.ch"
         git add .
         git commit -m "initial commit"
-    - uses: actions/download-artifact@master
-      with:
-        name: GeneratedProject
-        path: ./flying_circus
     - name: Create dev env (unpinned) and install package
       working-directory: ./flying_circus
       run: |

--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/download-artifact@master
       with:
         name: GeneratedProject
-        path: flying_circus
+        path: ./flying_circus
     - name: Create dev env (unpinned) and install package
       working-directory: ./flying_circus
       run: |

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ instructions. The URL has the form git(at)github.com:MeteoSwiss-APN/your_fancy_p
 
 ## Start developing your package
 
-For first steps, see the `README.md` of
-your package for some guidance. More details on package installation are also given in `docs/installation.rst` in your project repository. Find
+For first steps with your project, how to install it, setup and run the development tools, see the documentation of an example project, https://meteoswiss-apn.github.io/mch-python-blueprint/example_project/README.html. 
+Find
 out more about provided development tools and setting up CI/CD pipelines on https://meteoswiss-apn.github.io/mch-python-blueprint/ .
 
 ## Update template

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Copier does not work with older git versions (e.g. the standard one on Tsa). Not
 ## Set up your project on GitHub
 
 **Warning:** Before setting up your project, think carefully, whether you want to have your repository public or private and whether the provided licence
-suits your need. The package comes with an MIT license. Once you have made up your mind, go to the repository created by copier, i.e. your project
+suits your need. The package comes with an MIT license, therefore do not commit proprietary code before carefully reviewing or changing the license.
+Once you have made up your mind, go to the repository created by copier, i.e. your project
 repository and initialize git with the following sequence of commands:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ instructions. The URL has the form git(at)github.com:MeteoSwiss-APN/your_fancy_p
 
 ## Start developing your package
 
-For first steps with your project, how to install it, setup and run the development tools, see the documentation of an example project, https://meteoswiss-apn.github.io/mch-python-blueprint/example_project/README.html. 
+For first steps with your project, how to install it, setup and run the development tools, see the documentation of an example project, https://meteoswiss-apn.github.io/mch-python-blueprint/example_project/README.html.
 Find
 out more about provided development tools and setting up CI/CD pipelines on https://meteoswiss-apn.github.io/mch-python-blueprint/ .
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@ pip install copier
 You can now produce your Python package from a copier template by running
 ```
 conda activate blueprint
-copier --vcs-ref copier3_refine git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+copier git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
 ```
-The flag `--vcs-ref copier3_refine` makes sure the correct branch of the blueprint is checked out. This will be
-changed, once we have a release.
+If you need to generate your project from a specific commit hash or branch of the blueprint you can run with --vcs-ref
+
+```
+conda activate blueprint
+copier --vcs-ref <branch> git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+```
+
 **Warning:**
 Copier does not work with older git versions (e.g. the standard one on Tsa). Not having an up-to-date git version will lead to cryptic error messages. On CSCS machines, you can get an up-to-date git version with `module load git`.
 
@@ -61,7 +66,7 @@ out more about provided development tools and setting up CI/CD pipelines on http
 To update your package to the latest version of the underlying meta template, run:
 
 ```bash
-copier --vcs-ref copier3_refine -a .copier-answers.yml -f update
+copier -a .copier-answers.yml -f update
 ```
 
 With `-f`, conflicting files are overwritten (which doesn't mean that in the end, the files are changed as those conflicts can be purely internal).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,9 +13,6 @@ Getting Started
    :maxdepth: 2
 
    readme
-   example_project/README
-   example_project/docs/installation
-   example_project/USAGE
    faq
 
 Features

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,9 @@ Getting Started
    :maxdepth: 2
 
    readme
+   example_project/README
+   example_project/docs/installation
+   example_project/USAGE
    faq
 
 Features

--- a/tmpl/README.md.j2
+++ b/tmpl/README.md.j2
@@ -7,7 +7,7 @@ Check available options with
 ```bash
 setup_env.sh -h
 ```
-. We distinguish development installations which are editable and have additional dependencies on formatters and linters from productive installations which are non-editable
+We distinguish development installations which are editable and have additional dependencies on formatters and linters from productive installations which are non-editable
 and have no additional dependencies. Moreover we distinguish pinned installations based on exported (reproducible) environments and free installations where the installation
 is based on first level dependencies listed in `requirements/requirements.yml` and `requirements/dev-requirements.yml` respectively. If you start developing, you might want to do a free
 development installation and export the environments right away.
@@ -48,7 +48,7 @@ and in pull requests to the main branch.
 
 ### Jenkins
 Two jenkins plans are available in the `jenkins/` folder. On the one hand `jenkins/Jenkinsfile` controls the nightly (weekly, monthly, ...) builds, on the other hand
-`jenkins/JenkinsJobPR.j2` controls the pipeline invoked with the command `launch jenkins` in pull requests on GitHub. Your jenkins pipeline will not be set up
+`jenkins/JenkinsJobPR` controls the pipeline invoked with the command `launch jenkins` in pull requests on GitHub. Your jenkins pipeline will not be set up
 automatically. If you need to run your tests on CSCS machines, contact DevOps to help you with the setup of the pipelines. Otherwise, you can ignore the jenkinsfiles
 and exclusively run your tests and checks on GitHub actions.
 

--- a/tmpl/docs/documentation.inactive
+++ b/tmpl/docs/documentation.inactive
@@ -3,10 +3,10 @@ name: docs
 on:
   push:
     branches:
-    - dev_refactor
+    - main
   pull_request:
     branches:
-      - dev_refactor
+      - '*'
 
 jobs:
   build:

--- a/tmpl/docs/index.rst.j2
+++ b/tmpl/docs/index.rst.j2
@@ -8,7 +8,6 @@ Welcome to {{ project_name }}'s documentation!
    ../README
    installation
    ../USAGE
-   modules
    ../CONTRIBUTING
    ../AUTHORS
    ../HISTORY


### PR DESCRIPTION
Technical description
================

some changes to the triggers for building and content of the  documentation
* It will always build on any push to master, but also on any PR. 
* the deployment job (i.e. push to IO pages) happens only for pushes to master. This is to avoid that PRs are pushing builds to the official IO pages
* generate an example project and include a link in the documentation. So that users now how to proceed once the project is generated.