### PR TITLE
Jenkins/ GH actions fetch tmpl from HEAD

### DIFF
--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --data python_version=3.9 copy . flying_circus
+        conda run --name blueprint copier --force --data --vcs-ref=HEAD python_version=3.9 copy . flying_circus
     - name: Prepare new project
       working-directory: ./flying_circus
       run: |


### PR DESCRIPTION
The default behavior of copier is to fetch the template from the latest release tag of the blueprint repository (see e.g. [here](https://github.com/copier-org/copier/issues/184) When working on the blueprint, we need Github actions and Jenkins to fetch the template from HEAD since we want to test the latest commit. To this end, the flag `--vcs-ref=HEAD` has to be added in the jenkinsfile and actions workflow when invoking copier.

- was already set in Jenkinsfile
- adapted in GH actions workflow