### PR TITLE
Fix rst

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,11 @@ repos:
         additional_dependencies:
         -   sphinx==5.0.1
         -   sphinx-mdinclude
-        exclude: ( tmpl/ | docs/readme.rst )
+        exclude: |
+            (?x)^(
+                tmpl/|
+                docs/readme.rst|
+            )$
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,14 @@ repos:
         exclude: tmpl/
     -   id: check-yaml
         exclude: tmpl/
-#-   repo: https://github.com/myint/rstcheck
-#    rev: v6.1.0
-#    hooks:
-#    -   id: rstcheck
-#        additional_dependencies:
-#        -   sphinx==5.0.1
-#        -   sphinx-mdinclude
-#        exclude: tmpl/
+-   repo: https://github.com/myint/rstcheck
+    rev: v6.1.0
+    hooks:
+    -   id: rstcheck
+        additional_dependencies:
+        -   sphinx==5.0.1
+        -   sphinx-mdinclude
+        exclude: ( tmpl/ | docs/readme.rst )
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.2.1
     hooks:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -12,10 +12,10 @@ FAQ and Troubleshooting
 
 **A:** If you get lots of them, did you install your package with pip (add -e if you need an editable installation for development)?
 
-.. code-block::
+.. code-block:: bash
 
-    conda activate <package_env>
-    cd </package/root/directory>
+    conda activate package_env
+    cd /package/root/directory
     pip install --no-deps .
 
 If yes, are you sure you didn't miss any dependencies in :code:`requirements/requirements.yml` or
@@ -27,10 +27,10 @@ If yes, are you sure you didn't miss any dependencies in :code:`requirements/req
 
 **A:** Sure! If you want the pre-commit hooks to run automatically on every local commit, you can set up pre-commit locally.
 
-.. code-block::
+.. code-block:: bash
 
-    conda activate <dev-package_env>
-    cd </package/root/directory>
+    conda activate dev-package_env
+    cd /package/root/directory
     pre-commit install
 
 If you prefer to run pre-commit independent of committing, you can run the hooks over all files by


### PR DESCRIPTION
Fix rstcheck pre-commit hook

- Explicitly indicate language in code blocks for `faq.rst ` to fix `AttributeError ` (see [this](https://rstcheck-core.readthedocs.io/en/latest/faq/#code-blocks-without-language-sphinx))
- Exclude `docs/readme.rst` from hook as it is a linked md and mdinclude is an unknown statement to rstcheck.