### PR TITLE
Clean up copier params

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -1,11 +1,13 @@
 _subdirectory: "tmpl"
 _templates_suffix: ".j2"
 
+# author_name:
 full_name:
   help: "Your full name"
   default: "Monty Python"
   type: str
 
+# author_email:
 email:
   help: "Your email address"
   default: "{{ full_name.lower().replace(' ', '.') }}@meteoswiss.ch"
@@ -21,11 +23,13 @@ project_slug:
   default: "{{ project_name.lower().replace(\"'\", '').replace(' ', '-') }}"
   type: str
 
+# project_package:
 module_name:
   help: "Python module name (no spaces or dashes)"
   default: "{{ project_slug.replace('-', '_') }}"
   type: str
 
+# project_description:
 project_short_description:
   help: "Describe your project in one line"
   default: "{{ full_name }}'s {{ project_name }}"
@@ -36,12 +40,14 @@ project_keywords:
   default: "{{ project_name }}"
   type: str
 
+# project_git_user:
 github_username:
   help: "Name of github/gitlab user hosting the project"
   # default: "MeteoSwiss-APN"
   default: "{{ full_name.lower().replace(' ', '_') }}"
   type: str
 
+# project_git_url:
 project_github:
   help: "URL of project git repository"
   default: "https://github.com/{{ github_username }}/{{ project_slug }}"
@@ -57,6 +63,7 @@ project_doc_url:
   default: "https://github.io/{{ github_username }}/{{ project_slug }}"
   type: str
 
+# project_version:
 version:
   help: "Initial project version"
   default: "0.1.0"

--- a/copier.yaml
+++ b/copier.yaml
@@ -31,6 +31,10 @@ project_short_description:
   default: "{{ full_name }}'s {{ project_name }}"
   type: str
 
+project_keywords:
+  help: "Keywords that describe your project (comma-separated)"
+  default: "{{ project_name }}"
+  type: str
 
 github_username:
   help: "Name of github/gitlab user hosting the project"

--- a/copier.yaml
+++ b/copier.yaml
@@ -43,8 +43,8 @@ project_keywords:
 # project_git_user:
 github_username:
   help: "Name of github/gitlab user hosting the project"
-  # default: "MeteoSwiss-APN"
-  default: "{{ full_name.lower().replace(' ', '_') }}"
+  default: "MeteoSwiss-APN"
+  # default: "{{ full_name.lower().replace(' ', '_') }}" # for private projects
   type: str
 
 # project_git_url:

--- a/copier.yaml
+++ b/copier.yaml
@@ -34,11 +34,13 @@ project_short_description:
 
 github_username:
   help: "Name of github/gitlab user hosting the project"
+  # default: "MeteoSwiss-APN"
   default: "{{ full_name.lower().replace(' ', '_') }}"
   type: str
+
 project_github:
-  help: "Project path on github"
-  default: "MeteoSwiss-APN/{{ project_slug }}"
+  help: "URL of project git repository"
+  default: "https://github.com/{{ github_username }}/{{ project_slug }}"
   type: str
 
 version:

--- a/copier.yaml
+++ b/copier.yaml
@@ -11,11 +11,6 @@ email:
   default: "{{ full_name.lower().replace(' ', '.') }}@meteoswiss.ch"
   type: str
 
-github_username:
-  help: "Your user name on github"
-  default: "{{ full_name.lower().replace(' ', '_') }}"
-  type: str
-
 project_name:
   help: "Human-friendly project name"
   default: "Flying Circus"
@@ -36,6 +31,11 @@ project_short_description:
   default: "{{ full_name }}'s {{ project_name }}"
   type: str
 
+
+github_username:
+  help: "Your user name on github"
+  default: "{{ full_name.lower().replace(' ', '_') }}"
+  type: str
 project_github:
   help: "Project path on github"
   default: "MeteoSwiss-APN/{{ project_slug }}"

--- a/copier.yaml
+++ b/copier.yaml
@@ -12,12 +12,12 @@ email:
   type: str
 
 project_name:
-  help: "Human-friendly project name"
+  help: "Human-friendly project name used in READMEs etc."
   default: "Flying Circus"
   type: str
 
 project_slug:
-  help: "URL-friendly project name (no spaces)"
+  help: "URL-friendly project name used in github/gitlab URL etc. (no spaces)"
   default: "{{ project_name.lower().replace(\"'\", '').replace(' ', '-') }}"
   type: str
 
@@ -27,13 +27,13 @@ module_name:
   type: str
 
 project_short_description:
-  help: "Your project in one line"
+  help: "Describe your project in one line"
   default: "{{ full_name }}'s {{ project_name }}"
   type: str
 
 
 github_username:
-  help: "Your user name on github"
+  help: "Name of github/gitlab user hosting the project"
   default: "{{ full_name.lower().replace(' ', '_') }}"
   type: str
 project_github:

--- a/copier.yaml
+++ b/copier.yaml
@@ -47,6 +47,16 @@ project_github:
   default: "https://github.com/{{ github_username }}/{{ project_slug }}"
   type: str
 
+project_ssh_url:
+  help: "SSH URL of project git repository"
+  default: "{{ project_github.replace('https://', 'git+ssh://git@') }}.git"
+  type: str
+
+project_doc_url:
+  help: "URL of project documentation"
+  default: "https://github.io/{{ github_username }}/{{ project_slug }}"
+  type: str
+
 version:
   help: "Initial project version"
   default: "0.1.0"

--- a/tmpl/jenkins/JenkinsJobPR.j2
+++ b/tmpl/jenkins/JenkinsJobPR.j2
@@ -7,7 +7,7 @@ pipelineJob('{{ project_slug }}_PR') {
       scm {
         git {
           remote {
-            github('{{ project_github }}')
+            github('{{ github_username }}/{{ project_slug }}')
             refspec('+refs/pull/*:refs/remotes/origin/pr/*')
             credentials('466e4dd5-80af-4935-828f-a9fff24b46de')
           }

--- a/tmpl/pyproject.toml.j2
+++ b/tmpl/pyproject.toml.j2
@@ -24,7 +24,7 @@ authors = [
 ]
 
 [project.urls]
-source = "https://github.com/{{ github_username }}/{{ project_slug }}"
+source = "{{ project_github }}"
 #documentation = "https://github.io/{{ github_username }}/{{ project_slug }}"  TODO
 
 [project.scripts]

--- a/tmpl/pyproject.toml.j2
+++ b/tmpl/pyproject.toml.j2
@@ -27,7 +27,7 @@ authors = [
 
 [project.urls]
 source = "{{ project_github }}"
-#documentation = "https://github.io/{{ github_username }}/{{ project_slug }}"  TODO
+documentation = "{{ project_doc_url }}"
 
 [project.scripts]
 {{ project_slug }} = "{{ module_name }}.cli:main"

--- a/tmpl/pyproject.toml.j2
+++ b/tmpl/pyproject.toml.j2
@@ -9,7 +9,9 @@ version = "{{ version }}"
 description = "{{ project_short_description }}"
 readme = "README.rst"
 keywords = [
-    "{{ project_slug }}",
+{%- for keyword in project_keywords.split(",") %}
+    "{{ keyword.strip() }}",
+{%- endfor %}
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
- Improve some parameter descriptions
- Add new parameters `project_keywords`, `project_doc_url` and `project_ssh_url`
- Change `project_github` from partial to full github URL (enables support for other hosts)
- Add some better parameter names as comments in case renaming (as originally proposed in #83) ever happens