### PR TITLE
add option

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
                 set -e
                 cd ${WORKSPACE}/flying_circus
                 source ${WORKSPACE}/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 bash setup_env.sh -n flying_circus -u
                 conda activate flying_circus
@@ -49,7 +49,7 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate flying_circus
                 cd ${WORKSPACE}/flying_circus
                 pytest tests
@@ -61,7 +61,7 @@ pipeline {
                 sh '''#!/usr/bin/env bash
                 set -e
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 cd ${WORKSPACE}/flying_circus
                 bash setup_env.sh -n flying_circus -d -u
@@ -74,7 +74,7 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate flying_circus
                 cd ${WORKSPACE}/flying_circus
                 pytest tests
@@ -86,7 +86,7 @@ pipeline {
                 sh '''#!/usr/bin/env bash
                 set -e
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 cd ${WORKSPACE}/flying_circus
                 bash setup_env.sh -n pinned-flying_circus
@@ -110,7 +110,7 @@ pipeline {
                 sh '''#!/usr/bin/env bash
                 set -e
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 cd ${WORKSPACE}/flying_circus
                 bash setup_env.sh -n pinned-flying_circus -d

--- a/tmpl/jenkins/Jenkinsfile.j2
+++ b/tmpl/jenkins/Jenkinsfile.j2
@@ -27,7 +27,7 @@ pipeline {
                 set -e
                 cd ${WORKSPACE}/{{ project_slug }}
                 source ${WORKSPACE}/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 ./setup_env.sh -n {{ project_slug }} -u
                 conda activate {{ project_slug }}
@@ -39,7 +39,7 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate {{ project_slug }}
                 cd ${WORKSPACE}/{{ project_slug }}
                 pytest tests
@@ -51,7 +51,7 @@ pipeline {
                 sh '''#!/usr/bin/env bash
                 set -e
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 cd ${WORKSPACE}/{{ project_slug }}
                 ./setup_env.sh -n {{ project_slug }} -d -u
@@ -64,7 +64,7 @@ pipeline {
             steps {
                 sh '''#!/usr/bin/env bash
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate dev-{{ project_slug }}
                 cd ${WORKSPACE}/{{ project_slug }}
                 pytest tests
@@ -76,7 +76,7 @@ pipeline {
                 sh '''#!/usr/bin/env bash
                 set -e
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 cd ${WORKSPACE}/{{ project_slug }}
                 ./setup_env.sh -n pinned-{{ project_slug }}
@@ -100,7 +100,7 @@ pipeline {
                 sh '''#!/usr/bin/env bash
                 set -e
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
-                conda init bash
+                conda init bash --no-user --install --system
                 conda activate
                 cd ${WORKSPACE}/{{ project_slug }}
                 ./setup_env.sh -n pinned-{{ project_slug }} -d

--- a/tmpl/setup_miniconda.sh
+++ b/tmpl/setup_miniconda.sh
@@ -22,9 +22,6 @@ while getopts p:n  flag; do
     esac
 done
 
-echo $INSTALL_PREFIX
-echo $USER_INSTALL
-
 # Install conda executable if not yet available
 if [[ -f $CONDA_EXE ]]; then
     echo "Found a conda executable at: ${CONDA_EXE}"

--- a/tmpl/setup_miniconda.sh
+++ b/tmpl/setup_miniconda.sh
@@ -8,17 +8,17 @@
 
 # Default options
 INSTALL_PREFIX=${PWD}
-USER_INSTALL=true
+USER_INSTALL=false
 
 # here the conda version is fixed, the sha256 hash has to be set accordingly
 MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-x86_64.sh
 SHA256=00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6
 
 # Eval command line options
-while getopts p:n  flag; do
+while getopts p:u  flag; do
     case ${flag} in
         p) INSTALL_PREFIX=${OPTARG};;
-        n) USER_INSTALL=false;;
+        u) USER_INSTALL=true;;
     esac
 done
 

--- a/tmpl/setup_miniconda.sh
+++ b/tmpl/setup_miniconda.sh
@@ -8,17 +8,22 @@
 
 # Default options
 INSTALL_PREFIX=${PWD}
+USER_INSTALL=true
 
 # here the conda version is fixed, the sha256 hash has to be set accordingly
 MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-x86_64.sh
 SHA256=00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6
 
 # Eval command line options
-while getopts p: flag; do
+while getopts p:n  flag; do
     case ${flag} in
         p) INSTALL_PREFIX=${OPTARG};;
+        n) USER_INSTALL=false;;
     esac
 done
+
+echo $INSTALL_PREFIX
+echo $USER_INSTALL
 
 # Install conda executable if not yet available
 if [[ -f $CONDA_EXE ]]; then
@@ -31,7 +36,12 @@ else
     source ${INSTALL_PREFIX}/miniconda/etc/profile.d/conda.sh
     conda config --set always_yes yes --set changeps1 no
     conda config --add channels conda-forge
-    conda init bash
+    if ${USER_INSTALL}; then
+      conda init bash
+    else
+      # this is a workaround as plain --no-user is not working as it should
+      conda init bash --no-user --install --system
+    fi
     conda activate
     rm ${INSTALL_PREFIX}/miniconda.sh
 fi


### PR DESCRIPTION
This adds the option `-n` to the `setup_miniconda.sh` script.
This allows to conda init bash with `--no-user` which means that the `.bashrc` is not modified.