### PR TITLE
disable concurrent builds

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,4 +1,11 @@
 pipeline {
+    options {
+    // the variable $WORKSPACE is assigned dynamically at the beginning of every stage
+    // and might change depending on the number of concurrent builds active.
+    // We can only allow 1 concurrent build to have a consistent access to $WORKSPACE
+    // Otherwise we should use stash/unstash for the miniconda installation
+        disableConcurrentBuilds()
+    }
     environment {
        PATH = "$WORKSPACE/miniconda/bin:$PATH"
     }

--- a/tmpl/jenkins/Jenkinsfile.j2
+++ b/tmpl/jenkins/Jenkinsfile.j2
@@ -1,4 +1,11 @@
 pipeline {
+    options {
+    // the variable $WORKSPACE is assigned dynamically at the beginning of every stage
+    // and might change depending on the number of concurrent builds active.
+    // We can only allow 1 concurrent build to have a consistent access to $WORKSPACE
+    // Otherwise we should use stash/unstash for the miniconda installation
+        disableConcurrentBuilds()
+    }
     environment {
        PATH = "$WORKSPACE/miniconda/bin:$PATH"
     }


### PR DESCRIPTION
Description
==========

An issue with concurrent builds was encountered and fixed here: 
https://github.com/C2SM/iconarray/pull/47

the variable $WORKSPACE is assigned dynamically at the beginning of every stage
and might change depending on the number of concurrent builds active.
We can only allow 1 concurrent build to have a consistent access to $WORKSPACE
Otherwise we should use stash/unstash for the miniconda installation