### PR TITLE
Adaptations to new copier version and fix to avoid bash scripts being sourced 

### DIFF
--- a/.github/workflows/blueprint-docs.yml
+++ b/.github/workflows/blueprint-docs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier copy --force --vcs-ref=HEAD python_version=3.9 copy . ./docs/example_project
+        conda run --name blueprint copier copy --force --vcs-ref=HEAD . ./docs/example_project
         ls
         echo "==================================="
         ls docs

--- a/.github/workflows/blueprint-docs.yml
+++ b/.github/workflows/blueprint-docs.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --vcs-ref=HEAD python_version=3.9 copy . ./docs/example_project
+        conda run --name blueprint copier copy --force --vcs-ref=HEAD python_version=3.9 copy . ./docs/example_project
         ls
         echo "==================================="
         ls docs

--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier copy --force --vcs-ref=HEAD --data python_version=3.9 copy . flying_circus
+        conda run --name blueprint copier copy --force --vcs-ref=HEAD --data . flying_circus
     - name: Prepare new project
       working-directory: ./flying_circus
       run: |

--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier copy --force --vcs-ref=HEAD --data . flying_circus
+        conda run --name blueprint copier copy --force --vcs-ref=HEAD --data python_version=3.9 . flying_circus
     - name: Prepare new project
       working-directory: ./flying_circus
       run: |

--- a/.github/workflows/new-project.yml
+++ b/.github/workflows/new-project.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Create new project
       run: |
         # Note: Make sure python_version is consistent with python-version hardcoded above
-        conda run --name blueprint copier --force --vcs-ref=HEAD --data python_version=3.9 copy . flying_circus
+        conda run --name blueprint copier copy --force --vcs-ref=HEAD --data python_version=3.9 copy . flying_circus
     - name: Prepare new project
       working-directory: ./flying_circus
       run: |

--- a/README.md
+++ b/README.md
@@ -20,18 +20,19 @@ conda activate blueprint
 conda install pip
 pip install copier
 ```
+Make sure to have at least copier version 8.1.0. Otherwise, please update copier.
 
 ## Create your Python package from our template
 You can now produce your Python package from a copier template by running
 ```
 conda activate blueprint
-copier git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+copier copy git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
 ```
 If you need to generate your project from a specific commit hash or branch of the blueprint you can run with --vcs-ref
 
 ```
 conda activate blueprint
-copier --vcs-ref <branch> git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+copier copy --vcs-ref <branch> git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
 ```
 
 **Warning:**
@@ -69,7 +70,7 @@ out more about provided development tools and setting up CI/CD pipelines on http
 To update your package to the latest version of the underlying meta template, run:
 
 ```bash
-copier -a .copier-answers.yml -f update
+copier update -a .copier-answers.yml -f update
 ```
 
 With `-f`, conflicting files are overwritten (which doesn't mean that in the end, the files are changed as those conflicts can be purely internal).

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                 conda create -n copier
                 conda activate copier
                 conda install -c conda-forge copier
-                copier --vcs-ref=HEAD --defaults copy . flying_circus
+                copier copy --vcs-ref=HEAD --defaults copy . flying_circus
                 conda deactivate
                 '''
             }

--- a/requirements/requirements.yml
+++ b/requirements/requirements.yml
@@ -9,6 +9,6 @@ dependencies:
   - sphinx>=4.3
   - pip:
     # runtime
-    - copier>=6.1
+    - copier>=8.1
     # development
     - sphinx-mdinclude>=0.5

--- a/tmpl/README.md.j2
+++ b/tmpl/README.md.j2
@@ -13,6 +13,8 @@ is based on top-level dependencies listed in `requirements/requirements.yml`. If
 ```bash
 tools/setup_env.sh -u -e -n <package_env_name>
 ```
+*Hint*: Make sure to execute the bash scripts in `tools/` (do not source them as this can lead to issues)!
+
 *Hint*: If you are the package administrator, it is a good idea to understand what this script does, you can do everything manually with `conda` instructions.
 
 *Hint*: Use the flag `-m` to speed up the installation using mamba. Of course you will have to install mamba first (we recommend to install mamba into your base

--- a/tmpl/docs/installation.rst.j2
+++ b/tmpl/docs/installation.rst.j2
@@ -11,6 +11,7 @@ Preparation
 -----------
 
 To install {{ project_name }} you need a miniconda installation. You can either set up your miniconda installation manually or use the script `tools/setup_miniconda.sh`, which will download and install the latest version of miniconda.
+Make sure to execute the script (do not source it as this can lead to issues)!
 
 
 Installation of dependencies

--- a/tmpl/requirements/requirements.yml.j2
+++ b/tmpl/requirements/requirements.yml.j2
@@ -34,6 +34,6 @@ dependencies:
   - types-toml>=0.10
   - pip:
     # development
-    - copier>=7.0
+    - copier>=8.1
     - flake8-pyproject>=1.2
     - sphinx-mdinclude>=0.5

--- a/tmpl/tools/run-mypy.sh.j2
+++ b/tmpl/tools/run-mypy.sh.j2
@@ -9,6 +9,11 @@
 #
 # src: https://jaredkhan.com/blog/mypy-pre-commit
 
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  echo "Please simply call the script instead of sourcing it!"
+  return
+fi
+
 set -o errexit
 
 VERBOSE=${VERBOSE:-false}

--- a/tmpl/tools/setup_env.sh.j2
+++ b/tmpl/tools/setup_env.sh.j2
@@ -6,6 +6,11 @@
 # - 2022-09 (S. Ruedisuehli) Refactor; add some options
 #
 
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  echo "Please simply call the script instead of sourcing it!"
+  return
+fi
+
 # Default env names
 DEFAULT_ENV_NAME="{{ project_slug }}"
 

--- a/tmpl/tools/setup_miniconda.sh
+++ b/tmpl/tools/setup_miniconda.sh
@@ -6,6 +6,11 @@
 # - 2022-09 (S. Ruedisuehli) Refactor
 #
 
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  echo "Please simply call the script instead of sourcing it!"
+  return
+fi
+
 # Default options
 INSTALL_PREFIX=${PWD}
 USER_INSTALL=false

--- a/tools/update_env.sh
+++ b/tools/update_env.sh
@@ -10,7 +10,7 @@ main()
     if [[ -d "${tmpdir}" ]]; then
         \rm -rfv "${tmpdir}" || return
     fi
-    copier -f --vcs-ref=HEAD . "${tmpdir}" || return
+    copier copy -f --vcs-ref=HEAD . "${tmpdir}" || return
 
     # Use script in project to update the root environment file
     local env_name

--- a/tools/update_tmpl_env.sh
+++ b/tools/update_tmpl_env.sh
@@ -10,7 +10,7 @@ main()
     if [[ -d "${tmpdir}" ]]; then
         \rm -rfv "${tmpdir}" || return
     fi
-    copier -f --vcs-ref=HEAD . "${tmpdir}" || return
+    copier copy -f --vcs-ref=HEAD . "${tmpdir}" || return
 
     # Update the project's environment file
     \cd "${tmpdir}" || return


### PR DESCRIPTION
This PR includes
- improved documentation: 
  - Users tried to use the `tools/setup_miniconda.sh` script in sourcing it instead of executing it. This breaks the argument parsing of the script. It relies on `OPTIND` which is not reset when calling the script again, and the script then ignores the arguments. I included a hint in the documentation at two locations. 
  - Updated calls of copier since copier version 8.1.0 (the old commands do not work anymore)
- adaptation of github actions workflow to new copier version 
- check at the begining of the bash scripts to avoid them being sourced instead of executed 

It fixes #117 and ideally also fixes the jenkins plan which is currently failing.

Since the copier commands are not backward compatible, this version of the blueprint now works with the new version. Supporting both adds work...