### PR TITLE
Add instructions for correct usage of setup_miniconda.sh.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ First you have to install copier and its requirements. Ideally you do this in a 
 ```bash
 conda create --name blueprint
 conda activate blueprint
-conda install pip
-pip install copier
+conda install "copier<8.0"
 ```
 
 ## Create your Python package from our template

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GH pages of this repository (https://meteoswiss-apn.github.io/mch-python-bluepri
 
 ## Preparation
 
-Ensure that your active Python version is 3.11 or higher.
+Ensure that your active Python version is 3.7 or higher.
 The recommended way to manage Python versions is with `Conda`
 (https://docs.conda.io/en/latest/).
 On CSCS machines it is recommended to install the leaner `Miniconda`
@@ -40,20 +40,21 @@ First you have to install copier and its requirements. Ideally you do this in a 
 ```bash
 conda create --name blueprint
 conda activate blueprint
-conda install copier
+conda install pip
+pip install copier
 ```
 
 ## Create your Python package from our template
 You can now produce your Python package from a copier template by running
 ```
 conda activate blueprint
-copier copy git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+copier git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
 ```
 If you need to generate your project from a specific commit hash or branch of the blueprint you can run with --vcs-ref
 
 ```
 conda activate blueprint
-copier copy --vcs-ref <branch> git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+copier --vcs-ref <branch> git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
 ```
 
 **Warning:**

--- a/README.md
+++ b/README.md
@@ -8,30 +8,52 @@ More information on the tools, intended workflow, etc. can be found on
 GH pages of this repository (https://meteoswiss-apn.github.io/mch-python-blueprint/).
 
 ## Preparation
-Ensure that your active Python version is 3.7 or higher.
-The recommended way to manage Python versions is with `Conda` (https://docs.conda.io/en/latest/). On CSCS machines it is recommended to install the leaner `Miniconda` (https://docs.conda.io/en/latest/miniconda.html), which offers enough functionality for most of our use cases. If you don't want to do this step manually, you can also use the script that is provided in the copier template `tmpl/tools/setup_miniconda.sh`.
+
+Ensure that your active Python version is 3.11 or higher.
+The recommended way to manage Python versions is with `Conda`
+(https://docs.conda.io/en/latest/).
+On CSCS machines it is recommended to install the leaner `Miniconda`
+(https://docs.conda.io/en/latest/miniconda.html),
+which offers enough functionality for most of our use cases.
+If you don't want to do this step manually, you may use the script that is
+provided in the copier template `tmpl/tools/setup_miniconda.sh`.
+The default installation path of this script is the current working directory,
+you might want to change that with the `-p` option to a common location for all
+environments, like e.g. `$SCRATCH`. If you want the script to immediately
+initialize conda (executing `conda init` and thereby adding a few commands at the
+end of your `.bashrc`) after installation, add the `-u` option:
+
+```bash
+tmpl/tools/setup_miniconda.sh -p $SCRATCH -u
+```
+
+In case you ever need to uninstall miniconda, do the following:
+
+```bash
+conda init --reverse --all
+rm -rf $SCRATCH/miniconda
+```
 
 ## Install Copier
 
-First you have to install copier and its requirements. Ideally you do it in a conda environment. Either manually
+First you have to install copier and its requirements. Ideally you do this in a conda environment:
 ```bash
 conda create --name blueprint
 conda activate blueprint
-conda install pip
-pip install copier
+conda install copier
 ```
 
 ## Create your Python package from our template
 You can now produce your Python package from a copier template by running
 ```
 conda activate blueprint
-copier git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+copier copy git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
 ```
 If you need to generate your project from a specific commit hash or branch of the blueprint you can run with --vcs-ref
 
 ```
 conda activate blueprint
-copier --vcs-ref <branch> git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
+copier copy --vcs-ref <branch> git@github.com:MeteoSwiss-APN/mch-python-blueprint.git </path/to/destination>
 ```
 
 **Warning:**

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                 source $WORKSPACE/miniconda/etc/profile.d/conda.sh
                 conda create -n copier
                 conda activate copier
-                conda install -c conda-forge copier
+                conda install -c conda-forge "copier<8.0"
                 copier --vcs-ref=HEAD --defaults copy . flying_circus
                 conda deactivate
                 '''

--- a/tmpl/README.md.j2
+++ b/tmpl/README.md.j2
@@ -1,5 +1,34 @@
 # {{ project_name }}: {{ project_short_description }}
 
+## Preparation
+
+This project has been created from the
+[MeteoSwiss Python blueprint](https://github.com/MeteoSwiss-APN/mch-python-blueprint)
+for the CSCS.
+The recommended way to manage Python versions is with `Conda`
+(https://docs.conda.io/en/latest/).
+On CSCS machines it is recommended to install the leaner `Miniconda`
+(https://docs.conda.io/en/latest/miniconda.html),
+which offers enough functionality for most of our use cases.
+If you don't want to do this step manually, you may use the script
+`tools/setup_miniconda.sh`.
+The default installation path of this script is the current working directory,
+you might want to change that with the `-p` option to a common location for all
+environments, like e.g. `$SCRATCH`. If you want the script to immediately
+initialize conda (executing `conda init` and thereby adding a few commands at the
+end of your `.bashrc`) after installation, add the `-u` option:
+
+```bash
+tmpl/tools/setup_miniconda.sh -p $SCRATCH -u
+```
+
+In case you ever need to uninstall miniconda, do the following:
+
+```bash
+conda init --reverse --all
+rm -rf $SCRATCH/miniconda
+```
+
 ## Start developing
 
 Once you created or cloned this repository, make sure the installation is running properly. Install the package dependencies with the provided script `setup_env.sh`.

--- a/tmpl/tools/setup_miniconda.sh
+++ b/tmpl/tools/setup_miniconda.sh
@@ -13,8 +13,8 @@ INSTALL_PREFIX=${PWD}
 USER_INSTALL=false
 
 # here the conda version is fixed, the sha256 hash has to be set accordingly
-MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-x86_64.sh
-SHA256=00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6
+MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-x86_64.sh
+SHA256=d0643508fa49105552c94a523529f4474f91730d3e0d1f168f1700c43ae67595
 
 # Eval command line options
 while getopts p:u  flag; do

--- a/tmpl/tools/setup_miniconda.sh
+++ b/tmpl/tools/setup_miniconda.sh
@@ -13,8 +13,8 @@ INSTALL_PREFIX=${PWD}
 USER_INSTALL=false
 
 # here the conda version is fixed, the sha256 hash has to be set accordingly
-MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py311_23.10.0-1-Linux-x86_64.sh
-SHA256=d0643508fa49105552c94a523529f4474f91730d3e0d1f168f1700c43ae67595
+MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-x86_64.sh
+SHA256=00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6
 
 # Eval command line options
 while getopts p:u  flag; do

--- a/tmpl/tools/setup_miniconda.sh
+++ b/tmpl/tools/setup_miniconda.sh
@@ -13,8 +13,9 @@ INSTALL_PREFIX=${PWD}
 USER_INSTALL=false
 
 # here the conda version is fixed, the sha256 hash has to be set accordingly
-MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-Linux-x86_64.sh
-SHA256=00938c3534750a0e4069499baf8f4e6dc1c2e471c86a59caa0dd03f4a9269db6
+MINICONDA_URL=https://repo.anaconda.com/miniconda/Miniconda3-py310_23.9.0-0-Linux-x86_64.sh
+SHA256=b272a5f843762f0a18f6b70a162cd554a43a06adcd6f5a2102840e41907fffe5
+
 
 # Eval command line options
 while getopts p:u  flag; do


### PR DESCRIPTION
Add instructions for correct usage of setup_miniconda.sh. Update Python to 3.11 and Conda to 23 and adapt README.md and tmpl/README.md.j2 accordingly.